### PR TITLE
fix executableName generation for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function getDetails(version) {
   return {
     baseName: baseName,
     archiveName: archiveName,
-    executableName: executableName + executableExtension,
+    executableName: executableName,
     downloadLink: downloadLink,
     platform: platform,
     arch: arch,

--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ function getDetails(version) {
                          .replace(/\$\{platform\}/g, platform)
                          .replace(/\$\{arch\}/g, arch);
 
-  var executableName = '${baseName}/${baseName}${executableExtension}'
+  var basePath = '${baseName}'
+                         .replace(/\$\{baseName\}/g, baseName)  
+
+  var executableName = '${basePath}/${baseName}${executableExtension}'
+                         .replace(/\$\{basePath\}/g, basePath)
                          .replace(/\$\{baseName\}/g, baseName)
                          .replace(/\$\{executableExtension\}/g, executableExtension);
 
@@ -76,6 +80,7 @@ function getDetails(version) {
 
 
   return {
+    basePath: basePath,
     baseName: baseName,
     archiveName: archiveName,
     executableName: executableName,
@@ -125,7 +130,7 @@ function withHugo(version, callback) {
 
   download(installDetails.downloadLink, archivePath, function(err) {
 
-    var extractPath = path.dirname(archivePath);
+    var extractPath = path.join(path.dirname(archivePath), installDetails.basePath);
 
     if (err) {
       console.error('failed to download hugo: ' + err);


### PR DESCRIPTION
The executableName already containes the extension generated by the regex based placeholder replacement, so there is no need to add it again :)
