### PR TITLE
Handle environments where the default binary is /usr/bin/nodejs

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var cli = require('../');
 
 var args = process.argv;
 
-if (/node$|iojs$/.test(args[0])) {
+if (/node$|iojs$|nodejs$/.test(args[0])) {
   args = args.slice(2);
 }
 


### PR DESCRIPTION
On a default installation of ubuntu 16.04 the hugo-cli fails to launch any command due to the node binary being used — /usr/bin/nodejs.

While it is true that /usr/bin/node is also installed and available, the default environment does not use it when launching Hugo.

By adjusting the regex expression to also handle nodejs binaries, everything works :)
