### PR TITLE
[Fix #7] Updates logic to download and extract hugo; deprecates support for Hugo versions below 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "decompress": "^2.3.0",
     "mkdirp": "^0.5.1",
-    "request": "^2.60.0"
+    "request": "^2.60.0",
+    "semver": "^5.3.0"
   },
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi @nikku, first attempt at a solution so please shout up with any issues. This should resolve #7.

- Uses a map to lookup platforms for the download file
- Updates the returned object from getDetails (removed unnecessary properties to avoid confusion about what should be returned)
- Deprecates support for versions below 0.18.1 by using semver to do the comparison