### PR TITLE
Update decompress and strip leading folder from extracted files

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,8 @@ function download(url, target, callback) {
     .pipe(fileStream);
 }
 
-function extract(archivePath, destPath, callback) {
-  decompress({ mode: '755' })
-    .src(archivePath)
-    .dest(destPath)
-    .run(callback);
+function extract(archivePath, destPath) {
+  return decompress(archivePath, destPath);
 }
 
 
@@ -150,17 +147,15 @@ function withHugo(version, callback) {
 
     console.log('extracting archive...');
 
-    extract(archivePath, extractPath, function(err, files) {
-
-      if (err) {
-        console.error('failed to extract: ' + err);
-        return callback(err);
-      }
-
+    extract(archivePath, extractPath).then(function () {
       console.log('we got it, let\'s go!');
       console.log();
 
-      callback(err, executablePath);
+      callback(null, executablePath);
+    }, function (err) {
+      console.error('failed to extract: ' + err);
+
+      callback(err);
     });
 
   });

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function download(url, target, callback) {
 }
 
 function extract(archivePath, destPath) {
-  return decompress(archivePath, destPath);
+  return decompress(archivePath, destPath, { strip: 1 }); // strip: 1 here removes the leading folder
 }
 
 
@@ -66,7 +66,7 @@ function getDetails(version) {
   var baseName = 'hugo_${version}'.replace(/\$\{version\}/g, version);
 
   var executableName =
-        '${baseName}_${platform}_${arch}/${baseName}_${platform}_${arch}${executableExtension}'
+        '${baseName}_${platform}_${arch}${executableExtension}'
             .replace(/\$\{baseName\}/g, baseName)
             .replace(/\$\{platform\}/g, platform)
             .replace(/\$\{arch\}/g, arch_exec)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Nico Rehwaldt<git_nikku@nixis.de>",
   "license": "MIT",
   "dependencies": {
-    "decompress": "^2.3.0",
+    "decompress": "^4.0.0",
     "mkdirp": "^0.5.1",
     "request": "^2.60.0",
     "semver": "^5.3.0"


### PR DESCRIPTION
This PR aims to fix #10.

The changes:

- Updates `decompress` to v4.0.0
- Uses `strip` property to remove leading folder
- Removes folder from the `executableName` variable
- Updates the `decompress` API to reflect updated dependency changes