### PR TITLE
Fix arguments passed to Windows

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var cli = require('../');
 
 var args = process.argv;
 
-if (/node$|iojs$|nodejs$/.test(args[0])) {
+if (/node(\.exe)?$|iojs$|nodejs$/.test(args[0])) {
   args = args.slice(2);
 }
 


### PR DESCRIPTION
Hello - me again!

So my last fix worked when running the cli locally but when running it in Windows from another project (e.g. hugo-cli as a dep), it's passed arguments that it doesn't recognise:

```
[ 'C:\\Program Files\\nodejs\\node.exe',
  'C:\\<project path>\\node_modules\\hugo-cli\\bin\\cmd.js' ]
Error: unknown command "C:\\Program Files\\nodejs\\node.exe" for "hugo"
Run 'hugo --help' for usage.
```

This PR adds the .exe to the conditional regex to split the array.