### PR TITLE
Rename unversioned executable to versioned name

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,17 @@ function download(url, target, callback) {
     .pipe(fileStream);
 }
 
-function extract(archivePath, destPath) {
-  return decompress(archivePath, destPath, { strip: 1 }); // strip: 1 here removes the leading folder
+function extract(archivePath, destPath, installDetails) {
+  var unversionedHugoExecutable = "hugo" + path.extname(installDetails.executableName);
+
+  return decompress(archivePath, destPath,
+    {
+      strip: 1,
+      map: file => {
+        file.path = (path.basename(file.path) == unversionedHugoExecutable) ? installDetails.executableName : file.path;
+        return file;
+      }
+    });
 }
 
 
@@ -147,7 +156,7 @@ function withHugo(version, callback) {
 
     console.log('extracting archive...');
 
-    extract(archivePath, extractPath).then(function () {
+    extract(archivePath, extractPath, installDetails).then(function () {
       console.log('we got it, let\'s go!');
       console.log();
 

--- a/index.js
+++ b/index.js
@@ -122,6 +122,8 @@ function withHugo(version, callback) {
     return console.error('hugo-cli requires Hugo ' + HUGO_MIN_VERSION + ' or above. Version requested: ' + version);
   }
 
+  version = (version.endsWith('.0')) ? version.slice(0, -2) : version;
+
   var pwd = __dirname;
 
   var installDetails = getDetails(version);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function download(url, target, callback) {
 }
 
 function extract(archivePath, destPath, installDetails) {
-  var unversionedHugoExecutable = "hugo" + path.extname(installDetails.executableName);
+  var unversionedHugoExecutable = "hugo" + installDetails.executableExtension;
 
   return decompress(archivePath, destPath,
     {
@@ -97,7 +97,8 @@ function getDetails(version) {
   return {
     archiveName: archiveName,
     executableName: executableName,
-    downloadLink: downloadLink
+    downloadLink: downloadLink,
+    executableExtension: executableExtension
   };
 }
 


### PR DESCRIPTION
As of Hugo v0.20.3 the executable in the archive download no longer has a version number. This change renames the unversioned Hugo executable to the versioned name Hugo-cli is expecting