### PR TITLE
Allow Hugo extended versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
   - 'node'
+before_install:
+  # Required to avoid libstdc++ errors when running "extended" hugo
+  - wget -q -O libstdc++6 http://security.ubuntu.com/ubuntu/pool/main/g/gcc-5/libstdc++6_5.4.0-6ubuntu1~16.04.10_amd64.deb
+  - sudo dpkg --force-all -i libstdc++6
 
 script: npm test

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function extract(archivePath, destPath, installDetails) {
  * @param  {String} version
  * @return {Object}
  */
-function getDetails(version, target) {
+function getDetails(version, target, extended) {
 
   var arch_exec = '386',
       arch_dl = '-32bit',
@@ -84,7 +84,9 @@ function getDetails(version, target) {
     archiveExtension = '.zip';
   }
 
-  var baseName = 'hugo_${version}'.replace(/\$\{version\}/g, version);
+  var baseName = 'hugo_${extended}${version}'
+    .replace(/\$\{extended\}/g, (extended ? 'extended_' : ''))
+    .replace(/\$\{version\}/g, version);
 
   var executableName =
         '${baseName}_${platform}_${arch}${executableExtension}'
@@ -134,6 +136,12 @@ function withHugo(options, callback) {
 
   verbose && logDebug('target=%o, hugo=%o', TARGET, { version });
 
+  var extended = false;
+  if (version.indexOf('extended') !== -1) {
+    extended = true;
+    version = version.replace(/[^0-9\.]/g, '');
+  }
+
   if (semver.lt(version, HUGO_MIN_VERSION)) {
 
     logError('hugo-cli@%s is compatible with hugo >= %s only.', cliVersion, HUGO_MIN_VERSION)
@@ -146,7 +154,7 @@ function withHugo(options, callback) {
 
   var pwd = __dirname;
 
-  var installDetails = getDetails(version, TARGET);
+  var installDetails = getDetails(version, TARGET, extended);
 
   var installDirectory = path.join(pwd, 'tmp');
 
@@ -180,7 +188,7 @@ function withHugo(options, callback) {
       return callback(err);
     }
 
-    log('fetched hugo v%s', version);
+    log('fetched hugo v%s%s', version, (extended ? '/extended' : ''));
 
     log('extracting archive...');
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -7,10 +7,16 @@ describe('getDetails', function() {
 
   function verify(version, env, expectedDetails) {
 
-    it('hugo@' + version + ', env=' + util.inspect(env), function() {
+    var extended = false;
+    if (version.indexOf('extended') !== -1) {
+      extended = true;
+      version = version.replace(/[^0-9\.]/g, '');
+    }
+
+    it('hugo@' + version + (extended ? '/extended' : '') + ', env=' + util.inspect(env), function() {
 
       // when
-      var actualDetails = cli.getDetails(version, env);
+      var actualDetails = cli.getDetails(version, env, extended);
 
       // then
       assert.deepEqual(actualDetails, expectedDetails);
@@ -80,6 +86,29 @@ describe('getDetails', function() {
     downloadLink: 'https://github.com/gohugoio/hugo/releases/download/v0.45.1/hugo_0.45.1_Windows-32bit.zip',
     executableExtension: '.exe',
     executableName: 'hugo_0.45.1_windows_386.exe'
+  });
+
+  verify('0.45.1/extended', { platform: 'linux', arch: 'x64' }, {
+    archiveName: 'hugo_extended_0.45.1_Linux-64bit.tar.gz',
+    downloadLink: 'https://github.com/gohugoio/hugo/releases/download/v0.45.1/hugo_extended_0.45.1_Linux-64bit.tar.gz',
+    executableExtension: '',
+    executableName: 'hugo_extended_0.45.1_linux_amd64'
+  });
+
+
+  verify('0.45.1/extended', { platform: 'darwin', arch: 'x64' }, {
+    archiveName: 'hugo_extended_0.45.1_macOS-64bit.tar.gz',
+    downloadLink: 'https://github.com/gohugoio/hugo/releases/download/v0.45.1/hugo_extended_0.45.1_macOS-64bit.tar.gz',
+    executableExtension: '',
+    executableName: 'hugo_extended_0.45.1_darwin_amd64'
+  });
+
+
+  verify('0.45.1/extended', { platform: 'win32', arch: 'x64' }, {
+    archiveName: 'hugo_extended_0.45.1_Windows-64bit.zip',
+    downloadLink: 'https://github.com/gohugoio/hugo/releases/download/v0.45.1/hugo_extended_0.45.1_Windows-64bit.zip',
+    executableExtension: '.exe',
+    executableName: 'hugo_extended_0.45.1_windows_amd64.exe'
   });
 
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -13,6 +13,8 @@ describe('cmd', function() {
 
     verify('0.30.1', { HUGO_VERSION: '0.30.1' });
 
+    verify('0.45.1/extended', { HUGO_VERSION: '0.45.1/extended' });
+
     verify('0.45.1');
 
   });


### PR DESCRIPTION
I found myself in need of the extended version of Hugo today but, sadly, hugo-cli can't currently handle it.  I planned on just opening an issue but then I started digging into it and here we are.  The way I've gone about this, it isn't *too* picky about how "extended" is added into the `HUGO_VERSION` environment variable.  For example, both "0.45.1/extended" and "extended_0.45.1" work fine (whether you're thinking of the version output from Hugo or the release naming conventions, respectively).

I can at least say that it works properly on macOS 64-bit (one of the handful of supported targets for the extended version) but there may be a more elegant way of implementing the required modifications.  If you would like me to go about this in a different way, just let me know.

Otherwise, hey, thanks for hugo-cli.  I was looking for an easy way of making Hugo available to anyone who wants to modify a project I'm working on (which already uses npm) and this certainly helps lower the barrier to entry.


Edit: I can't tell from the Travis log but from some testing on a similar target (Linux 64-bit), it seems like the extended binary *might* be failing with an error like this (when the test tries to get the version string): ```hugo_extended_0.45.1_linux_amd64: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by hugo_extended_0.45.1_linux_amd64)```

I'll look into it more when I get a chance.  I imagine the .travis.yml file might need to be tweaked to ensure the environment can properly execute the binary.