### PR TITLE
run hugo in current working directory

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -24,5 +24,12 @@ cli.withHugo(options, function(err, hugoPath) {
     process.exit(1);
   }
 
-  spawn(hugoPath, args, { stdio: 'inherit' });
+  var spawnOptions = { stdio: 'inherit' };
+
+  // INIT_CWD = cwd where "npm run-script hugo" is run
+  if (process.env.INIT_CWD) {
+    spawnOptions.cwd = process.env.INIT_CWD;
+  }
+
+  spawn(hugoPath, args, spawnOptions);
 });


### PR DESCRIPTION
This pull requests lets Hugo run in the current working directory from where `npm run hugo` is called.
This enables working with Hugo project(s) in sub directories (example below).

The implementation uses the **`INIT_CWD`** environment variable that is set by [npm run-script](https://docs.npmjs.com/cli/run-script) and passes it as the **`cwd`** option to [spawn](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).

---

Because npm scripts are always run from the root of the package module, hugo-cli always runs from root independent of the actual working directory.

This causes problems, when the **hugo project** (or multiple projects) is stored in **sub directories**.
```
- package.json
- HUGO_PROJECT/
    - config.toml
- ...
```

```
$ cd HUGO_PROJECT/
$ npm run hugo

Error: Unable to locate Config file. Perhaps you need to create a new site.
       Run `hugo help new` for details.
```



In order to work with a folder structure like the one above, one would have to use `npm run hugo -- --source HUGO_PROJECT` to tell Hugo not to use the npm package's root folder but the actual project folder.

This is not only annoying but also differs from the way a regular installation of Hugo works, i.e., always running from the current working directory.
