### PR TITLE
Support hugo versions >= 0.54.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var chalk = require('chalk');
 var HUGO_BASE_URL = 'https://github.com/gohugoio/hugo/releases/download';
 var HUGO_MIN_VERSION = '0.20.0';
 var HUGO_DEFAULT_VERSION = process.env.HUGO_VERSION || '0.52.0';
+var HUGO_MIN_VERSION_NEW_URL_SCHEMA = '0.54.0';
 
 var TARGET = {
   platform: process.platform,
@@ -146,7 +147,9 @@ function withHugo(options, callback) {
     return callback(new Error(`incompatible with hugo@${version}`));
   }
 
-  compatVersion = (compatVersion.endsWith('.0')) ? compatVersion.slice(0, -2) : compatVersion;
+  if (semver.lt(compatVersion, HUGO_MIN_VERSION_NEW_URL_SCHEMA)) {
+    compatVersion = (compatVersion.endsWith('.0')) ? compatVersion.slice(0, -2) : compatVersion;
+  }
 
   var pwd = __dirname;
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -69,7 +69,7 @@ function verify(version, cliEnv={}) {
 
     var stdout = result.stdout;    
 
-    if (stdout.indexOf(`Hugo Static Site Generator v${expectedVersion} `) === -1) {
+    if (stdout.indexOf(`Hugo Static Site Generator v${expectedVersion}`) === -1) {
       throw new Error(
         `expected <hugo version> to report:
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -27,6 +27,7 @@ describe('cmd', function() {
 
     verify('0.54.0', { HUGO_VERSION: '0.54.0' });
 
+    verify('0.54.0/extended', { HUGO_VERSION: '0.54.0/extended' });
   });
 
 });
@@ -67,9 +68,15 @@ function verify(version, cliEnv={}) {
 
     var expectedVersion = version.endsWith('.0') ? version.replace(/\.0$/, '') : version;
 
-    var stdout = result.stdout;    
+    var extended = /^extended_|\/extended$/.test(version);
 
-    if (stdout.indexOf(`Hugo Static Site Generator v${expectedVersion}`) === -1) {
+    expectedVersion = extended ? version.replace(/^extended_|\/extended$/, '') : expectedVersion;
+
+    var stdout = result.stdout;
+
+    // Check for expectedVersion in output and for optional extended version
+    if (!(stdout.indexOf(`Hugo Static Site Generator v${expectedVersion}`) >= 0
+      && (!extended || stdout.indexOf('extended') >= 0))) {
       throw new Error(
         `expected <hugo version> to report:
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -23,6 +23,10 @@ describe('cmd', function() {
 
     verify('0.45/extended', { HUGO_VERSION: '0.45.0/extended' });
 
+    verify('0.53.0', { HUGO_VERSION: '0.53.0' });
+
+    verify('0.54.0', { HUGO_VERSION: '0.54.0' });
+
   });
 
 });
@@ -63,7 +67,7 @@ function verify(version, cliEnv={}) {
 
     var expectedVersion = version.endsWith('.0') ? version.replace(/\.0$/, '') : version;
 
-    var stdout = result.stdout;
+    var stdout = result.stdout;    
 
     if (stdout.indexOf(`Hugo Static Site Generator v${expectedVersion} `) === -1) {
       throw new Error(


### PR DESCRIPTION
Hugo version >= 0.54.0 have da different download url so they won't be fetched from the current implementation. I fixed this by skipping the trimming of the version string for "X.X.0" versions.
I also found out, that from version 0.53.0 ongoing the command line output has changed. They now include a git commit hash or something like that. So I also adjusted the test suite, so it can handle the new output.