### PR TITLE
Configure Travis CI to use Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
-language:
-  - node_js
-
+dist: xenial
+language: node_js
 node_js:
   - node
-
-before_install:
-  # Required to avoid libstdc++ errors when running "extended" hugo
-  - wget -q -O libstdc++6 http://security.ubuntu.com/ubuntu/pool/main/g/gcc-5/libstdc++6_5.4.0-6ubuntu1~16.04.10_amd64.deb
-  - sudo dpkg --force-all -i libstdc++6
-
 script:
   - npm run all


### PR DESCRIPTION
Before Ubuntu Xenial 16.04 was available on Travis CI, we had to use a `before_install` step in `.travis.yml` to download and install Xenial's libstdc++ on Trusty to be able to successfully test Hugo "extended" builds. Now that Xenial's available, we can simply use `dist: xenial`. Seeing as I added the previous workaround in the process of adding support for Hugo's extended versions, I thought it would be a good idea to clean it up.