### PR TITLE
fix(cmd): set exit code

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var spawn = require('child_process').spawn;
+var spawnSync = require('child_process').spawnSync;
 
 var cli = require('../');
 
@@ -24,5 +24,6 @@ cli.withHugo(options, function(err, hugoPath) {
     process.exit(1);
   }
 
-  spawn(hugoPath, args, { stdio: 'inherit' });
+  process.exit(spawnSync(hugoPath, args, { stdio: 'inherit' }).status);
 });
+


### PR DESCRIPTION
This makes sure that the exit code of the `hugo` executable is propagated from `cmd.js` to the calling process. Otherwise when `hugo-cli` is run from npm/yarn and error occur the error is not properly signaled.